### PR TITLE
デフォルトの公開範囲からパブリックを無効化 (TASK-10)

### DIFF
--- a/packages/backend/migration/1700580088833-default-note-visibility.js
+++ b/packages/backend/migration/1700580088833-default-note-visibility.js
@@ -1,0 +1,14 @@
+export class DefaultNoteVisibility1700580088833 {
+    name = 'DefaultNoteVisibility1700580088833'
+
+    async up(queryRunner) {
+        const registryItems = await queryRunner.query(`SELECT "id" FROM "registry_item" WHERE "scope" = $1 AND "key" = $2 AND "value" = $3`, ['{client,base}', 'defaultNoteVisibility', '"public"']);
+        registryItems.forEach(async (item) => {
+            await queryRunner.query(`UPDATE "registry_item" SET "value" = $1, "updatedAt" = $2 WHERE "id" = $3`, ['"home"', new Date(), item.id]);
+        });
+    }
+
+    async down(queryRunner) {
+        //
+    }
+}

--- a/packages/backend/src/core/RegistryApiService.ts
+++ b/packages/backend/src/core/RegistryApiService.ts
@@ -27,6 +27,11 @@ export class RegistryApiService {
 	public async set(userId: MiUser['id'], domain: string | null, scope: string[], key: string, value: any) {
 		// TODO: 作成できるキーの数を制限する
 
+		if (key === 'defaultNoteVisibility' && value === 'public') {
+			// eslint-disable-next-line no-param-reassign
+			value = 'home';
+		}
+
 		const query = this.registryItemsRepository.createQueryBuilder('item');
 		if (domain) {
 			query.where('item.domain = :domain', { domain: domain });

--- a/packages/frontend/src/components/MkPostForm.vue
+++ b/packages/frontend/src/components/MkPostForm.vue
@@ -459,6 +459,9 @@ function setVisibility() {
 		changeVisibility: v => {
 			visibility = v;
 			if (defaultStore.state.rememberNoteVisibility) {
+				if (visibility === 'public') {
+					visibility = 'home';
+				}
 				defaultStore.set('visibility', visibility);
 			}
 		},

--- a/packages/frontend/src/pages/settings/privacy.vue
+++ b/packages/frontend/src/pages/settings/privacy.vue
@@ -50,7 +50,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 				<div class="_gaps_m">
 					<MkSelect v-model="defaultNoteVisibility">
-						<option value="public">{{ i18n.ts._visibility.public }}</option>
+						<!-- <option value="public">{{ i18n.ts._visibility.public }}</option> -->
 						<option value="home">{{ i18n.ts._visibility.home }}</option>
 						<option value="followers">{{ i18n.ts._visibility.followers }}</option>
 						<option value="specified">{{ i18n.ts._visibility.specified }}</option>

--- a/packages/frontend/src/pages/settings/privacy.vue
+++ b/packages/frontend/src/pages/settings/privacy.vue
@@ -49,6 +49,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 				<template v-else-if="defaultNoteVisibility === 'specified'" #suffix>{{ i18n.ts._visibility.specified }}</template>
 
 				<div class="_gaps_m">
+					<MkInfo>このサーバでは「デフォルトの公開範囲」に「パブリック」は選択できません</MkInfo>
 					<MkSelect v-model="defaultNoteVisibility">
 						<!-- <option value="public">{{ i18n.ts._visibility.public }}</option> -->
 						<option value="home">{{ i18n.ts._visibility.home }}</option>
@@ -71,6 +72,7 @@ import MkSwitch from '@/components/MkSwitch.vue';
 import MkSelect from '@/components/MkSelect.vue';
 import FormSection from '@/components/form/section.vue';
 import MkFolder from '@/components/MkFolder.vue';
+import MkInfo from '@/components/MkInfo.vue';
 import * as os from '@/os.js';
 import { defaultStore } from '@/store.js';
 import { i18n } from '@/i18n.js';

--- a/packages/frontend/src/store.ts
+++ b/packages/frontend/src/store.ts
@@ -76,7 +76,7 @@ export const defaultStore = markRaw(new Storage('base', {
 	},
 	defaultNoteVisibility: {
 		where: 'account',
-		default: 'public',
+		default: 'home',
 	},
 	defaultNoteLocalOnly: {
 		where: 'account',


### PR DESCRIPTION
- [x]  新規ユーザのデフォルト設定値を「ホーム」に変更する
- [x]  設定画面にある「デフォルトの公開範囲」から「パブリック」を無効化する
- [x]  設定画面に案内文を表示する
- [x]  「公開範囲を記憶する」を有効にした状態でパブリック投稿したとき、記憶する設定値を「ホーム」に変換する
- [x]  レジストリの保存時に「パブリック」だったら「ホーム」に変換する
- [x]  既存ユーザかつ「パブリック」を設定しているユーザは、強制的に「ホーム」に変更する